### PR TITLE
fix: provide src files

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "vite": "^2.5.10"
   },
   "files": [
-    "dist/**/*"
+    "dist/**/*",
+    "src/**/*"
   ],
   "release-it": {
     "hooks": {


### PR DESCRIPTION
In order to debug the library it would be great if you could provide the src files as well. Otherwise the devtools will not find the source code that are referenced in the source maps.