### PR TITLE
fix: remove popper warning

### DIFF
--- a/src/config/transitions.ts
+++ b/src/config/transitions.ts
@@ -1,13 +1,13 @@
 // eslint-disable-next-line import/prefer-default-export
 export const enterAndLeave = {
   // @tw
-  enterActiveClass: 'transition duration-100 ease-out',
+  enterActiveClass: 'transition-opacity duration-100 ease-out',
   // @tw
   enterFromClass: 'transform scale-95 opacity-0',
   // @tw
   enterToClass: 'transform scale-100 opacity-100',
   // @tw
-  leaveActiveClass: 'transition duration-75 ease-in',
+  leaveActiveClass: 'transition-opacity duration-75 ease-in',
   // @tw
   leaveFromClass: 'transform scale-100 opacity-100',
   // @tw


### PR DESCRIPTION
Currently, there is a warning when opening a dropdown control:
![image](https://user-images.githubusercontent.com/5358638/142990522-ebb34510-0f5e-413d-a176-b4683bfb1200.png)

This warning appears when there is a transition for any of the following properties: 'transform', 'top', 'right', 'bottom', 'left'. Tailwind class `transition` sets `transition-property: background-color, border-color, color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;`. Hence, if we use `transition-opacity` we can avoid the warning.

If you still would like to use `transition` and thus transition the `transform` prop I think we need to add a wrapper:
https://popper.js.org/docs/v2/faq/#how-do-i-add-css-transitions-without-disabling-adaptive